### PR TITLE
Streamline Workflow by Removing Node

### DIFF
--- a/.github/workflows/minify.yml
+++ b/.github/workflows/minify.yml
@@ -34,7 +34,8 @@ jobs:
       - run: html-minifier bio/index.html      -o bio/index.html      --collapse-whitespace --html5 --remove-comments --minify-css --minify-js
 
       # push to gh-pages branch
-      - run: |
+      - if: github.event_name != 'pull_request'
+        run: |
           git config user.name "Travis Heavener"
           git config user.email "travis.heavener@gmail.com"
           git commit -am "Automated minification of ${{ github.sha }}"

--- a/.github/workflows/minify.yml
+++ b/.github/workflows/minify.yml
@@ -10,17 +10,8 @@ jobs:
   minify:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [22.x]
-
     steps:
       - uses: actions/checkout@v4
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
 
       # install deps
       - run: npm install clean-css-cli -g


### PR DESCRIPTION
## About
The Minify workflow had remnants of a Node workflow template that was initially used, so I have removed it in hopes of troubleshooting the issues it was having with passing builds for commits against PRs.