### PR TITLE
[Misc.] Improve Shebang & Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*               text=auto
+*.sh		text eol=lf

--- a/tools/fetch_robots_txt.sh
+++ b/tools/fetch_robots_txt.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 DOWNLOAD_URL=$(curl -s https://api.github.com/repos/ai-robots-txt/ai.robots.txt/releases/latest | grep -Po "(?<=\"browser_download_url\": \")(.*?)(?=\")")
 curl -Ls "$DOWNLOAD_URL" > docs/robots.txt

--- a/tools/minify.sh
+++ b/tools/minify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 find docs -type f -name "*.css" -exec rm {} \;
 rmdir docs/css
 find docs -type f -name "*.js" -exec terser {} -o {} \;


### PR DESCRIPTION
## About
When pulling to new device, CRLF overwrote LF in Bash scripts. I've improved the shebang and added a .gitattributes file to prevent this in the future.